### PR TITLE
Fix docker images in production mode

### DIFF
--- a/ops/docker/prod/nginx/Dockerfile
+++ b/ops/docker/prod/nginx/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.25.3-alpine3.18-slim
 
 COPY ./ops/docker/prod/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY ./ops/docker/prod/nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY . /var/www/html
 

--- a/ops/docker/prod/nginx/nginx.conf
+++ b/ops/docker/prod/nginx/nginx.conf
@@ -1,0 +1,43 @@
+user nginx;
+worker_processes 1;
+
+error_log /var/log/nginx/errorlog.log warn;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 20000;
+}
+
+http {
+  fastcgi_cache_path /var/cache/nginx levels=1:2 keys_zone=microcache:10m max_size=1024m inactive=1h;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log /var/log/nginx/accesslog.log main;
+
+  sendfile on;
+
+  keepalive_timeout 65;
+  fastcgi_buffers 8 16k;
+  fastcgi_buffer_size 32k;
+  fastcgi_connect_timeout 300;
+  fastcgi_send_timeout 300;
+  fastcgi_read_timeout 300;
+
+  #tcp_nopush on;
+  gzip on;
+  gzip_disable "msie6";
+
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/ops/docker/prod/php-fpm/Dockerfile
+++ b/ops/docker/prod/php-fpm/Dockerfile
@@ -25,6 +25,8 @@ COPY . /var/www/html
 
 WORKDIR /var/www/html
 
+RUN composer install --no-interaction --no-dev --prefer-dist
+
 EXPOSE 9000
 
 CMD ["php-fpm"]


### PR DESCRIPTION
Images in production mode are not working properly due to details in the `microcache` and the lack of `composer install`.

![image](https://github.com/not-empty/ala-microframework-php/assets/54029589/cf0b4e4f-08a8-47f1-998c-68d4cedeb4a6)

To complement these points this `PR` adds the `composer install` command to `pdf-fpm` and includes the `nginx.conf` file, present in the [not-empty/nginx-alpine](https://github.com/not-empty/nginx-alpine), to `nginx`.